### PR TITLE
Fix Maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,19 +22,14 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org</groupId>
-        <artifactId>jbox2d</artifactId>
-        <version>1.0</version>
+        <groupId>org.jbox2d</groupId>
+        <artifactId>jbox2d-library</artifactId>
+        <version>2.2.1.1</version>
     </dependency>
     <dependency>
-        <groupId>javax</groupId>
+        <groupId>javax.vecmath</groupId>
         <artifactId>vecmath</artifactId>
-        <version>1.0</version>
-    </dependency>
-     <dependency>
-        <groupId>net.sf</groupId>
-        <artifactId>janalogtv</artifactId>
-        <version>1.0</version>
+        <version>1.5.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Summary
- use modern jbox2d and vecmath artifacts from Maven Central
- remove unused janalogtv dependency

## Testing
- `mvn -q clean package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68816e4a06808323ae249c2cbdac6ca6