### PR TITLE
Implement ship-following camera

### DIFF
--- a/src/main/java/net/force2dev/fysix/FysixMain.java
+++ b/src/main/java/net/force2dev/fysix/FysixMain.java
@@ -255,10 +255,8 @@ public class FysixMain {
         levelPoly01.addPoint(1200,1200);
         
         Point2d viewCoordUL = new Point2d();
-        //viewCoordUL.x = fo1.getPosition().x; 
-        //viewCoordUL.y = fo1.getPosition().y;
-        viewCoordUL.x = moon.getPosition().x; 
-        viewCoordUL.y = moon.getPosition().y;
+        viewCoordUL.x = fo1.getPosition().x;
+        viewCoordUL.y = fo1.getPosition().y;
         
         Dimension frameSize = r.getSize();
         
@@ -362,10 +360,8 @@ public class FysixMain {
                 	fo1.getPosition().y = 1;
                 }
                 
-                //viewCoordUL.x = fo1.getPosition().x*scaleFactor-frameSize.width/2.0; 
-                //viewCoordUL.y = fo1.getPosition().y*scaleFactor-frameSize.height/2.0;
-                viewCoordUL.x = planet.getPosition().x*scaleFactor-frameSize.width/2.0; 
-                viewCoordUL.y = planet.getPosition().y*scaleFactor-frameSize.height/2.0;
+                viewCoordUL.x = fo1.getPosition().x*scaleFactor-frameSize.width/2.0;
+                viewCoordUL.y = fo1.getPosition().y*scaleFactor-frameSize.height/2.0;
                 
 
 //                System.out.println(" X: " + fo1.getPosition().x*scaleFactor + " , Y: " + fo1.getPosition().y*scaleFactor + " CX: " + fo1.getPosition().x + " , CY: " + fo1.getPosition().y);


### PR DESCRIPTION
## Summary
- make the camera start at the player's ship
- update panning logic to track the ship instead of the planet

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_688282701ff48323af5c67efd26e0264